### PR TITLE
Mongodb service name and configuration path

### DIFF
--- a/mongodb/init.sls
+++ b/mongodb/init.sls
@@ -2,8 +2,10 @@
 # the id of the minion
 # NOTE: Currently this will not work behind a NAT in AWS VPC. 
 # see http://lodge.glasgownet.com/2012/07/11/apt-key-from-behind-a-firewall/comment-page-1/ for details
+{% from "mongodb/map.jinja" import mongodb with context %}
 
 {% set version        = salt['pillar.get']('mongodb:version', none) %}
+{% set package_name   = salt['pillar.get']('mongodb:package_name', "mongodb-10gen") %}
 
 {% if version is not none %}
 
@@ -25,7 +27,7 @@ mongodb_package:
     - keyid: 7F0CEB10
     - keyserver: keyserver.ubuntu.com
   pkg.installed:
-    - name: mongodb-10gen
+    - name: {{ package_name }}
     - version: {{ version }}
     {% else %}
   pkg.installed:
@@ -50,14 +52,14 @@ mongodb_log_path:
 
 mongodb_service:
   service.running:
-    - name: mongodb
+    - name: {{ mongodb.mongod }}
     - enable: True
     - watch:
       - file: mongodb_configuration
 
 mongodb_configuration:
   file.managed:
-    - name: /etc/mongodb.conf
+    - name: {{ mongodb.conf_path }}
     - user: root
     - group: root
     - mode: 644

--- a/mongodb/map.jinja
+++ b/mongodb/map.jinja
@@ -1,8 +1,12 @@
 {% set mongodb = salt['grains.filter_by']({
     'Debian': {
         'pip': 'python-pip',
+        'mongod': 'mongod',
+        'conf_path': '/etc/mongod.conf'
     },
     'RedHat': {
         'pip': 'python-pip',
+        'mongod': 'mongodb',
+        'conf_path': '/etc/mongodb.conf'
     },
 }, merge=salt['pillar.get']('mongodb:lookup')) %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,7 @@
 mongodb:
   use_ppa: True
   version: 2.4.8
+  package_name: mongodb-10gen
   mongo_directory: /mongodb
   manage_replica_set: False
   reconfigure_replica_set: False


### PR DESCRIPTION
Flexible mongodb package name

Using pillar: `package_name` you can set you own preferred package name
- mongodb-10gen
- mongodb-org

Flexible mongod.conf path

Actually mongod.conf is used as main configuration file
