### PR TITLE
Renamed mongod to mongodb value for Debian

### DIFF
--- a/mongodb/map.jinja
+++ b/mongodb/map.jinja
@@ -1,7 +1,7 @@
 {% set mongodb = salt['grains.filter_by']({
     'Debian': {
         'pip': 'python-pip',
-        'mongod': 'mongod',
+        'mongod': 'mongodb',
         'mongos': 'mongos',
         'conf_path': '/etc/mongod.conf'
     },


### PR DESCRIPTION
This affects #10, before I couldn't install mongodb at all, when ppa set
to false.
