### PR TITLE
Version in pillar doesn't even exist on mirrors anymore

### DIFF
--- a/mongodb/init.sls
+++ b/mongodb/init.sls
@@ -4,10 +4,7 @@
 # see http://lodge.glasgownet.com/2012/07/11/apt-key-from-behind-a-firewall/comment-page-1/ for details
 {% from "mongodb/map.jinja" import mongodb with context %}
 
-{% set version        = salt['pillar.get']('mongodb:version', '2.6.4') %}
 {% set package_name   = salt['pillar.get']('mongodb:package_name', "mongodb-10gen") %}
-
-{% if version is not none %}
 
 {% set settings       = salt['pillar.get']('mongodb:settings', {}) %}
 {% set replica_set    = salt['pillar.get']('mongodb:replica_set', {}) %}
@@ -30,7 +27,6 @@ mongodb_package:
     - keyserver: keyserver.ubuntu.com
   pkg.installed:
     - name: {{ package_name }}
-    - version: {{ version }}
 {% else %}
   pkg.installed:
      - name: mongodb
@@ -87,5 +83,3 @@ mongodb_logrotate:
     - group: root
     - mode: 440
     - source: salt://mongodb/files/logrotate.jinja
-
-{% endif %}

--- a/mongodb/mongos/init.sls
+++ b/mongodb/mongos/init.sls
@@ -1,9 +1,6 @@
 {% from "mongodb/map.jinja" import mongodb with context %}
 
-{% set version        = salt['pillar.get']('mongodb:version', none) %}
 {% set package_name   = salt['pillar.get']('mongos:package_name', "mongodb-org-mongos") %}
-
-{% if version is not none %}
 
 {% set use_ppa        = salt['pillar.get']('mongos:use_ppa', none) %}
 {% set settings       = salt['pillar.get']('mongos:settings', {}) %}
@@ -20,7 +17,6 @@ mongos_package:
     - keyserver: keyserver.ubuntu.com
   pkg.installed:
     - name: {{ package_name }}
-    - version: {{ version }}
     {% else %}
   pkg.installed:
      - name: mongos
@@ -76,5 +72,3 @@ mongos_logrotate:
     - group: root
     - mode: 440
     - source: salt://mongodb/mongos/files/logrotate.jinja
-
-{% endif %}


### PR DESCRIPTION
Obviously nobody isn't going to keep up with the versions every time something
new is released, so just let it pull the latest. If someone wants to step up to
maintain that in the future, it should be easy to add back in.