### PR TITLE
Update pillar.example to match removal of package versions

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,6 +1,5 @@
 mongodb:
   use_ppa: True
-  version: 2.6.4
   package_name: mongodb-10gen
   mongo_directory: /mongodb
   include_tools: True
@@ -16,7 +15,6 @@ mongodb:
 
 mongos:
   use_ppa: True
-  version: 2.6.4
   package_name: mongodb-org-mongos
   settings:
     log_file: /mongodb/log/mongos.log


### PR DESCRIPTION
In a previous patch I removed the ability to install specific package versions
as they weren't being kept up to date. Forgot to update the pillar.example.