### PR TITLE
Fixed default replica set value.

### DIFF
--- a/mongodb/defaults.yaml
+++ b/mongodb/defaults.yaml
@@ -14,7 +14,7 @@ mongodb:
   shard_svr: True
 
   replica_set:
-    name: None
+    name: null
 
   settings:
     port: 27017


### PR DESCRIPTION
The default value of None was being interpreted as the string "None",
breaking attempts to set up a standalone server. The canonical way
to specify a null value in YAML is "null" according to the reference
[here](http://www.yaml.org/refcard.html).