### PR TITLE
configuration for repo component

### DIFF
--- a/mongodb/codenamemap.yaml
+++ b/mongodb/codenamemap.yaml
@@ -3,7 +3,9 @@ trusty:
   use_repo: True
   mongodb_package: mongodb-org
   mongos_package: mongodb-org-mongos
+  repo_component: multiverse
 precise:
   use_repo: True
   mongodb_package: mongodb-org
   mongos_package: mongodb-org-mongos
+  repo_component: multiverse

--- a/mongodb/defaults.yaml
+++ b/mongodb/defaults.yaml
@@ -9,6 +9,7 @@ mongodb:
   db_path: /data/db
   use_repo: False
   use_ppa: False
+  repo_component: main
 
   config_svr: False
   shard_svr: True

--- a/mongodb/init.sls
+++ b/mongodb/init.sls
@@ -10,7 +10,7 @@ mongodb_package:
   {% set code = salt['grains.get']('oscodename') %}
   pkgrepo.managed:
     - humanname: MongoDB.org Repo
-    - name: deb http://repo.mongodb.org/apt/{{ os }} {{ code }}/mongodb-org/stable main
+    - name: deb http://repo.mongodb.org/apt/{{ os }} {{ code }}/mongodb-org/stable {{ mdb.repo_component }}
     - file: /etc/apt/sources.list.d/mongodb.list
     - keyid: 7F0CEB10
     - keyserver: keyserver.ubuntu.com


### PR DESCRIPTION
https://docs.mongodb.org/manual/tutorial/install-mongodb-on-ubuntu/

For Mongodb 3.0 the repo url has component called `multiverse` instead of main. This changeset makes it configurable