### PR TITLE
update defaults using grain filtered maps

### DIFF
--- a/mongodb/map.jinja
+++ b/mongodb/map.jinja
@@ -6,8 +6,8 @@
     default=salt['grains.filter_by'](osmap), merge=True) %}
 {% set code_map = salt['grains.filter_by'](codemap, grain='oscodename') %}
 
-{% do defaults.mongodb.update(osmap) %}
-{% do defaults.mongodb.update(codemap) %}
+{% do defaults.mongodb.update(distro_map) %}
+{% do defaults.mongodb.update(code_map) %}
 
 {% set mdb = salt['pillar.get']('mongodb', default=defaults.mongodb, merge=True) %}
 {% set ms = salt['pillar.get']('mongos', default=defaults.mongos, merge=True) %}


### PR DESCRIPTION
`osmap` and `codemap` were being filtered by grains, but the resulting values were never used (the original unfiltered maps were), meaning the values in those maps we not being applied.

