### PR TITLE
Update example pillar to reflect latest code

### DIFF
--- a/mongodb/defaults.yaml
+++ b/mongodb/defaults.yaml
@@ -6,6 +6,7 @@ mongodb:
 
   conf_path: /etc/mongodb.conf
   log_path: /var/log/mongodb
+  log_append: True
   db_path: /data/db
   use_repo: False
   version: stable
@@ -14,6 +15,7 @@ mongodb:
 
   config_svr: False
   shard_svr: True
+  rest: False
 
   replica_set:
     name: null

--- a/mongodb/files/mongodb.conf.jinja
+++ b/mongodb/files/mongodb.conf.jinja
@@ -5,6 +5,7 @@ bind_ip = {{ mdb.settings.bind_ip }}
 port = {{ mdb.settings.port }}
 dbpath = {{ mdb.db_path }}
 logpath = {{ mdb.log_path }}/mongodb.log
+logappend = {{ mdb.log_append }}
 
 {% if mdb.replica_set.name -%}
 replSet = {{ mdb.replica_set.name }}
@@ -20,4 +21,8 @@ configsvr=true
 
 {% if mdb.shard_svr == True %}
 shardsvr=true
+{% endif %}
+
+{% if mdb.rest == True %}
+rest=true
 {% endif %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,22 +1,26 @@
 mongodb:
-  use_ppa: True
+  use_repo: True
   version: 3.2
-  package_name: mongodb-10gen
+  repo_component: multiverse
+  mongodb_package: mongodb-org
   mongo_directory: /mongodb
-  manage_replica_set: False
-  reconfigure_replica_set: False
+  replica_set:
+    name: squiggles
   config_svr: False
   shard_svr: False
   storage_engine: wiredTiger
+  db_path: /mongodb/data
+  log_path: /mongodb/log
+  log_append: True
+  conf_path: /etc/mongodb.conf
+  rest: True
   settings:
-    db_path: /mongodb/data
-    log_path: /mongodb/log
-    log_append: True
-    rest: True
+    bind_ip: 127.0.0.1
+    port: 27017
 
 mongos:
-  use_ppa: True
-  package_name: mongodb-org-mongos
+  use_repo: True
+  mongos_package: mongodb-org-mongos
+  log_file: /mongodb/log/mongos.log
   settings:
-    log_file: /mongodb/log/mongos.log
     config_svrs: "cfg1.local:27019,cfg2.local:27019,cfg3.local:27019"


### PR DESCRIPTION
I noticed the pillar.example file referenced incorrect values and I personally found it very confusing, so I updated it to reflect the most recent changes.

I also added the log_append and rest options that are present in pillar example, but were missing from the config.