### PR TITLE
Add debian jessie support

### DIFF
--- a/mongodb/codenamemap.yaml
+++ b/mongodb/codenamemap.yaml
@@ -9,3 +9,7 @@ precise:
   mongodb_package: mongodb-org
   mongos_package: mongodb-org-mongos
   repo_component: multiverse
+jessie:
+  use_repo: False
+  mongodb_package: mongodb-server
+  mongos_package: mongodb-server


### PR DESCRIPTION
This patch make mongodb installable on debian 8 and makes use of official repository.
This should fix #26 
