### PR TITLE
Make mongod user configurable

### DIFF
--- a/mongodb/defaults.yaml
+++ b/mongodb/defaults.yaml
@@ -3,6 +3,8 @@ mongodb:
   mongos_package: mongos
   pip: python-pip
   mongod: mongodb
+  mongodb_user: mongodb
+  mongodb_group: mongodb
 
   conf_path: /etc/mongodb.conf
   log_path: /var/log/mongodb

--- a/mongodb/init.sls
+++ b/mongodb/init.sls
@@ -21,8 +21,8 @@ mongodb_package:
 mongodb_db_path:
   file.directory:
     - name: {{ mdb.db_path }}
-    - user: mongodb
-    - group: mongodb
+    - user: {{ mdb.mongodb_user }}
+    - group: {{ mdb.mongodb_group }}
     - mode: 755
     - makedirs: True
     - recurse:
@@ -32,8 +32,8 @@ mongodb_db_path:
 mongodb_log_path:
   file.directory:
     - name: {{ mdb.log_path }}
-    - user: mongodb
-    - group: mongodb
+    - user: {{ mdb.mongodb_user }}
+    - group: {{ mdb.mongodb_group }}
     - mode: 755
     - makedirs: True
 


### PR DESCRIPTION
Hi again!
This little patch makes mongofb user and group configurable making ``mongodb`` default as it was earlier.