### PR TITLE
Allow "setParameters" values to be set. 

### DIFF
--- a/mongodb/files/mongodb.conf.jinja
+++ b/mongodb/files/mongodb.conf.jinja
@@ -27,8 +27,8 @@ shardsvr=true
 rest=true
 {% endif %}
 
-{% if 'setParameter' in mdb -%}
-  {% for k,v in mdb.setParameter.iteritems() -%}
+{% if 'set_parameter' in mdb -%}
+  {% for k,v in mdb.set_parameter.iteritems() -%}
 setParameter = {{ k }}={{ v }}
   {% endfor -%}
 {% endif -%}

--- a/mongodb/files/mongodb.conf.jinja
+++ b/mongodb/files/mongodb.conf.jinja
@@ -26,3 +26,10 @@ shardsvr=true
 {% if mdb.rest == True %}
 rest=true
 {% endif %}
+
+{% if 'setParameter' in mdb -%}
+  {% for k,v in mdb.setParameter.iteritems() -%}
+setParameter = {{ k }}={{ v }}
+  {% endfor -%}
+{% endif -%}
+

--- a/pillar.example
+++ b/pillar.example
@@ -14,6 +14,8 @@ mongodb:
   log_append: True
   conf_path: /etc/mongodb.conf
   rest: True
+  set_parameter:
+    textSearchEnabled: 'true'
   settings:
     bind_ip: 127.0.0.1
     port: 27017


### PR DESCRIPTION
I needed to add text searching, which is enabled with the setParameter config entry. Hopefully this is useful to others as well.

An example config pillar:

    mongodb:
      setParameter:
        textSearchEnabled: 'true'

All values in the setParameter dictionary will get their own setParameter = ... entry in the config file.