### PR TITLE
Feature/yaml config format

### DIFF
--- a/mongodb/files/mongodb.conf.jinja
+++ b/mongodb/files/mongodb.conf.jinja
@@ -1,6 +1,12 @@
 {% from "mongodb/map.jinja" import mdb with context -%}
 # This file is managed by Salt!
 
+{% if 'mongod_settings' in mdb -%}
+
+{{ mdb.mongod_settings | yaml(false) }}
+
+{% else -%}
+
 bind_ip = {{ mdb.settings.bind_ip }}
 port = {{ mdb.settings.port }}
 dbpath = {{ mdb.db_path }}
@@ -33,3 +39,4 @@ setParameter = {{ k }}={{ v }}
   {% endfor -%}
 {% endif -%}
 
+{% endif-%}

--- a/mongodb/init.sls
+++ b/mongodb/init.sls
@@ -20,7 +20,11 @@ mongodb_package:
 
 mongodb_db_path:
   file.directory:
+{% if 'mongod_settings' in mdb %}
+    - name: {{ mdb.mongod_settings.storage.dbPath }}
+{% else %}
     - name: {{ mdb.db_path }}
+{% endif %}
     - user: {{ mdb.mongodb_user }}
     - group: {{ mdb.mongodb_group }}
     - mode: 755
@@ -31,7 +35,11 @@ mongodb_db_path:
 
 mongodb_log_path:
   file.directory:
+{% if 'mongod_settings' in mdb %}
+    - name: {{ salt['file.dirname'](mdb.mongod_settings.systemLog.path) }}
+{% else %}
     - name: {{ mdb.log_path }}
+{% endif %}
     - user: {{ mdb.mongodb_user }}
     - group: {{ mdb.mongodb_group }}
     - mode: 755

--- a/pillar.example
+++ b/pillar.example
@@ -3,7 +3,6 @@ mongodb:
   version: 3.2
   repo_component: multiverse
   mongodb_package: mongodb-org
-  mongo_directory: /mongodb
   replica_set:
     name: squiggles
   config_svr: False
@@ -19,6 +18,30 @@ mongodb:
   settings:
     bind_ip: 127.0.0.1
     port: 27017
+
+## For versions of Mongo that use the YAML format for configuration, use the 
+## following. All entries in mongod_settings are written to the config file 
+## verbatim. The storage:dbPath and systemLog:path entries are required in
+## this usage and take precedence over db_path at the top level (see references
+## in mongodb/init.sls).
+# mongodb:
+#   conf_path: /etc/mongod.conf
+#   mongod: mongod
+#   version: 3.2
+#   mongod_settings:
+#     setParameter:
+#       textSearchEnabled: true
+#     net:
+#       port: 27017
+#       bindIp: 0.0.0.0
+#     storage:
+#       dbPath: /var/lib/mongodb
+#       journal:
+#         enabled: true
+#     systemLog:
+#       destination: file
+#       logAppend: true
+#       path: /var/log/mongodb/mongod.log
 
 mongos:
   use_repo: True


### PR DESCRIPTION
Addresses issue #31. The idea is that if you want to use a mongo version that needs YAML-style configuration then you can create a `mongod_settings` section to hold the config entries which are then dumped directly into mongo's config file. If this section is found, the database and log paths are pulled from it and used in `mongodb/init.sls`. Fair warning: I don't use mongos and did not attempt to make a similar change for it.