### PR TITLE
Fix defaults to install of MongoDB 3.X stable from official repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# VIM editor swap files
+.*.sw?
+# Backups
+*~
+*.bak

--- a/README.rst
+++ b/README.rst
@@ -32,13 +32,13 @@ Install/configure MongoDB query router service.
 
 This state requires ``mongos:settings:config_svrs`` Pillar to be set correctly, its value will be
 substituted as argument for ``--configdb`` option of ``mongos`` executable (in the configuration
-file). See `MongoDB reference maual`_ for additional information.
+file). See `MongoDB reference manual`_ for additional information.
 
 .. note::
 
   The state currently works only on Ununtu LTS releases 12.04 and 14.04.
 
-.. _`MongoDB reference maual`: https://docs.saltstack.com/en/latest/topics/mine/index.html
+.. _`MongoDB reference manual`: https://docs.saltstack.com/en/latest/topics/mine/index.html
 
 ``mongodb.tools``
 -----------------

--- a/README.rst
+++ b/README.rst
@@ -1,28 +1,59 @@
 mongodb
 =======
 
-Install and configure various parts of a mongodb cluster.
+Install and configure various parts of a MongoDB cluster.
 
 Available states
 ================
 
-
 ``mongodb``
 -----------
 
-Install mongodb server and service.
+Install MongoDB server and run the service.
+
+By default the latest stable version of MongoDB 3.X packages will be installed from official
+repository at `repo.mongodb.org`_.
+
+.. note::
+
+  On Debian 8 (or later) MongoDB 2.4 packages will be installed from distribution repository.
+
+.. _`repo.mongodb.org`: https://repo.mongodb.org/
 
 ``mongodb.logrotate``
 ---------------------
 
-Install mongodb logrotate configuration file.
+Install MongoDB logrotate configuration file.
 
 ``mongodb.mongos``
 ------------------
 
-Install/configure mongo query router service.
+Install/configure MongoDB query router service.
+
+This state requires ``mongos:settings:config_svrs`` Pillar to be set correctly, its value will be
+substituted as argument for ``--configdb`` option of ``mongos`` executable (in the configuration
+file). See `MongoDB reference maual`_ for additional information.
+
+.. note::
+
+  The state currently works only on Ununtu LTS releases 12.04 and 14.04.
+
+.. _`MongoDB reference maual`: https://docs.saltstack.com/en/latest/topics/mine/index.html
 
 ``mongodb.tools``
 -----------------
 
 Install additional tools and python libraries.
+
+Operating systems support
+=========================
+
+This formula works "out-of-the-box" and tested on those operating systems:
+
+- CentOS/Red Hat Enterprise Linux 5, 6 and 7
+- Debian GNU/Linux 8 "Jessie" (stable)
+- Ubuntu LTS 12.04
+- Ubuntu LTS 14.04
+
+
+.. vim: fenc=utf-8 spell spl=en cc=100 tw=99 fo=want sts=2 sw=2 et

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,10 @@ repository at `repo.mongodb.org`_.
 
 .. note::
 
-  On Debian 8 (or later) MongoDB 2.4 packages will be installed from distribution repository.
+  By default on Debian 8 (or later) MongoDB 2.4 packages will be installed from distribution
+  repository. It is also possible to install newer version from `repo.mongodb.org`_ by setting
+  ``mongodb:lookup:use_repo`` Pillar to the ``True`` and other related keys. See ``pillar.example``
+  file for details.
 
 .. _`repo.mongodb.org`: https://repo.mongodb.org/
 

--- a/mongodb/codenamemap.yaml
+++ b/mongodb/codenamemap.yaml
@@ -1,15 +1,44 @@
+default: {}
+
 # mongodb.org only supply Ubuntu repos for LTS releases
 trusty:
   use_repo: True
-  mongodb_package: mongodb-org
-  mongos_package: mongodb-org-mongos
   repo_component: multiverse
+  mongodb_package: mongodb-org
+
+  mongod: mongod
+  conf_path: /etc/mongod.conf
+
+  mongod_settings:
+    systemLog:
+      destination: file
+      logAppend: true
+      path: /var/log/mongodb/mongod.log
+    storage:
+      dbPath: /var/lib/mongodb
+      journal:
+        enabled: true
+    net:
+      port: 27017
+      bindIp: 127.0.0.1
+
 precise:
   use_repo: True
-  mongodb_package: mongodb-org
-  mongos_package: mongodb-org-mongos
   repo_component: multiverse
-jessie:
-  use_repo: False
-  mongodb_package: mongodb-server
-  mongos_package: mongodb-server
+  mongodb_package: mongodb-org
+
+  mongod: mongod
+  conf_path: /etc/mongod.conf
+
+  mongod_settings:
+    systemLog:
+      destination: file
+      logAppend: true
+      path: /var/log/mongodb/mongod.log
+    storage:
+      dbPath: /var/lib/mongodb
+      journal:
+        enabled: true
+    net:
+      port: 27017
+      bindIp: 127.0.0.1

--- a/mongodb/defaults.yaml
+++ b/mongodb/defaults.yaml
@@ -1,12 +1,12 @@
 mongodb:
   use_repo: False
+  # This is useful default with use_repo: True
   version: stable
-  # Debian/Ubuntu specific
-  repo_component: main
 
   mongodb_package: mongodb
   pip: python-pip
 
+  # MongoDB 2.4 configuration
   mongodb_user: mongodb
   mongodb_group: mongodb
   mongod: mongodb

--- a/mongodb/defaults.yaml
+++ b/mongodb/defaults.yaml
@@ -1,43 +1,38 @@
 mongodb:
+  use_repo: False
+  version: stable
+  # Debian/Ubuntu specific
+  repo_component: main
+
   mongodb_package: mongodb
-  mongos_package: mongos
   pip: python-pip
-  mongod: mongodb
+
   mongodb_user: mongodb
   mongodb_group: mongodb
+  mongod: mongodb
 
   conf_path: /etc/mongodb.conf
   log_path: /var/log/mongodb
-  log_append: True
-  db_path: /data/db
-  use_repo: False
-  version: stable
-  use_ppa: False
-  repo_component: main
-
-  config_svr: False
-  shard_svr: True
-  rest: False
-
-  replica_set:
-    name: null
-
-  storage_engine: null
+  db_path: /var/lib/mongodb
 
   settings:
+    log_append: True
     port: 27017
     bind_ip: 127.0.0.1
+    journal: True
+    configsvr: False
+    shardsvr: False
+    replSet: ''
+    rest: False
 
 mongos:
-  mongos_package: mongos
+  use_repo: True
+  mongos_package: mongodb-org-mongos
+
   log_path: /var/log/mongos
   log_file: /var/log/mongos/mongos.log
-  conf_path: /etc/mongodb.conf
+  conf_path: /etc/mongos.conf
   mongos: mongos
-
-  use_repo: False
-  use_ppa: False
 
   settings:
     port: 27017
-    config_svrs: ""

--- a/mongodb/files/mongodb.conf.jinja
+++ b/mongodb/files/mongodb.conf.jinja
@@ -1,42 +1,56 @@
-{% from "mongodb/map.jinja" import mdb with context -%}
+{%- from "mongodb/map.jinja" import mdb with context -%}
+
 # This file is managed by Salt!
 
 {% if 'mongod_settings' in mdb -%}
 
+# mongod.conf
+
+# for documentation of all options, see:
+#   http://docs.mongodb.org/manual/reference/configuration-options/
+
 {{ mdb.mongod_settings | yaml(false) }}
 
-{% else -%}
+{%- else -%}
+
+# mongodb.conf
+
+# Where to store the data.
+dbpath={{ mdb.db_path }}
+
+# Where to log.
+logpath={{ mdb.log_path }}/mongodb.log
+
+logappend={{ mdb.settings.log_append | yaml_encode() }}
 
 bind_ip = {{ mdb.settings.bind_ip }}
 port = {{ mdb.settings.port }}
-dbpath = {{ mdb.db_path }}
-logpath = {{ mdb.log_path }}/mongodb.log
-logappend = {{ mdb.log_append }}
 
-{% if mdb.replica_set.name -%}
+# Enable journaling, http://www.mongodb.org/display/DOCS/Journaling
+journal={{ mdb.settings.journal | yaml_encode() }}
+
+    {%- if mdb.settings.configsvr %}
+
+configsvr={{ mdb.settings.configsvr }}
+
+    {%- elif mdb.settings.shardsvr %}
+
+shardsvr={{ mdb.settings.shardsvr }}
+
+    {%- endif %}
+
+    {%- if mdb.settings.replSet and not mdb.settings.configsvr %}
 replSet = {{ mdb.replica_set.name }}
-{% endif %}
+    {%- endif %}
 
-{% if mdb.storage_engine -%}
-storageEngine = {{ mdb.storage_engine }}
-{% endif %}
+    {%- if mdb.settings.rest %}
 
-{% if mdb.config_svr == True %}
-configsvr=true
-{% endif %}
+rest={{ mdb.settings.rest }}
 
-{% if mdb.shard_svr == True %}
-shardsvr=true
-{% endif %}
+    {%- endif %}
 
-{% if mdb.rest == True %}
-rest=true
-{% endif %}
-
-{% if 'set_parameter' in mdb -%}
-  {% for k,v in mdb.set_parameter.iteritems() -%}
+{% for k, v in mdb.settings.set_parameter | default({}) | dictsort() %}
 setParameter = {{ k }}={{ v }}
-  {% endfor -%}
-{% endif -%}
+{%- endfor %}
 
-{% endif-%}
+{%- endif %}

--- a/mongodb/init.sls
+++ b/mongodb/init.sls
@@ -1,62 +1,90 @@
 # This setup for mongodb assumes that the replica set can be determined from
 # the id of the minion
-# NOTE: Currently this will not work behind a NAT in AWS VPC.
-# see http://lodge.glasgownet.com/2012/07/11/apt-key-from-behind-a-firewall/comment-page-1/ for details
-{% from "mongodb/map.jinja" import mdb with context %}
 
-mongodb_package:
-{% if mdb.use_ppa or mdb.use_repo %}
-  {% set os = salt['grains.get']('os')|lower %}
-  {% set code = salt['grains.get']('oscodename') %}
+{%- from "mongodb/map.jinja" import mdb with context -%}
+
+{%- if mdb.use_repo %}
+
+  {%- if grains['os_family'] == 'Debian' %}
+
+    {%- set os   = salt['grains.get']('os') | lower() %}
+    {%- set code = salt['grains.get']('oscodename') %}
+
+mongodb_repo:
   pkgrepo.managed:
     - humanname: MongoDB.org Repo
     - name: deb http://repo.mongodb.org/apt/{{ os }} {{ code }}/mongodb-org/{{ mdb.version }} {{ mdb.repo_component }}
-    - file: /etc/apt/sources.list.d/mongodb.list
-    - keyid: 7F0CEB10
+    - file: /etc/apt/sources.list.d/mongodb-org.list
+    - keyid: EA312927
     - keyserver: keyserver.ubuntu.com
-{% endif %}
-  pkg.installed:
-     - name: {{ mdb.mongodb_package }}
 
-mongodb_db_path:
+  {%- elif grains['os_family'] == 'RedHat' %}
+
+mongodb_repo:
+  pkgrepo.managed:
+    {%- if mdb.version == 'stable' %}
+    - name: mongodb-org
+    - humanname: MongoDB Repository
+    {%- else %}
+    - name: mongodb-org-{{ mdb.version }}
+    - humanname: MongoDB {{ mdb.version | capitalize() }} Repository
+    {%- endif %}
+    - baseurl: https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/{{ mdb.version }}/$basearch/
+    - gpgcheck: 0
+    - enabled: 1
+
+  {%- endif %}
+
+{%- endif %}
+
+mongodb_packages:
+  pkg.installed:
+    - name: {{ mdb.mongodb_package }}
+
+mongodb_log_path:
   file.directory:
-{% if 'mongod_settings' in mdb %}
-    - name: {{ mdb.mongod_settings.storage.dbPath }}
-{% else %}
-    - name: {{ mdb.db_path }}
-{% endif %}
+{%- if 'mongod_settings' in mdb %}
+    - name: {{ salt['file.dirname'](mdb.mongod_settings.systemLog.path) }}
+{%- else %}
+    - name: {{ mdb.log_path }}
+{%- endif %}
     - user: {{ mdb.mongodb_user }}
     - group: {{ mdb.mongodb_group }}
     - mode: 755
     - makedirs: True
     - recurse:
-        - user
-        - group
+      - user
+      - group
 
-mongodb_log_path:
+mongodb_db_path:
   file.directory:
-{% if 'mongod_settings' in mdb %}
-    - name: {{ salt['file.dirname'](mdb.mongod_settings.systemLog.path) }}
-{% else %}
-    - name: {{ mdb.log_path }}
-{% endif %}
+  {%- if 'mongod_settings' in mdb %}
+    - name: {{ mdb.mongod_settings.storage.dbPath }}
+  {%- else %}
+    - name: {{ mdb.db_path }}
+  {%- endif %}
     - user: {{ mdb.mongodb_user }}
     - group: {{ mdb.mongodb_group }}
     - mode: 755
     - makedirs: True
+    - recurse:
+      - user
+      - group
+
+mongodb_config:
+  file.managed:
+    - name: {{ mdb.conf_path }}
+    - source: salt://mongodb/files/mongodb.conf.jinja
+    - template: jinja
+    - user: root
+    - group: root
+    - mode: 644
 
 mongodb_service:
   service.running:
     - name: {{ mdb.mongod }}
     - enable: True
+    - require:
+      - file: mongodb_db_path
     - watch:
-      - file: mongodb_configuration
-
-mongodb_configuration:
-  file.managed:
-    - name: {{ mdb.conf_path }}
-    - user: root
-    - group: root
-    - mode: 644
-    - source: salt://mongodb/files/mongodb.conf.jinja
-    - template: jinja
+      - file: mongodb_config

--- a/mongodb/map.jinja
+++ b/mongodb/map.jinja
@@ -2,8 +2,10 @@
 {% import_yaml "mongodb/osmap.yaml" as osmap %}
 {% import_yaml "mongodb/codenamemap.yaml" as codemap %}
 
-{% set distro_map = salt['pillar.get']('mongodb:lookup',
-    default=salt['grains.filter_by'](osmap), merge=True) %}
+{% set distro_map = salt['pillar.get'](
+    'mongodb:lookup',
+    default=salt['grains.filter_by'](osmap),
+    merge=True) %}
 {% set code_map = salt['grains.filter_by'](codemap, grain='oscodename') %}
 
 {% do defaults.mongodb.update(distro_map) %}

--- a/mongodb/osmap.yaml
+++ b/mongodb/osmap.yaml
@@ -1,4 +1,31 @@
+default: {}
+
 Debian:
+  # Install MongoDB 2.4 from Debian repo
+  use_repo: False
+  mongodb_package: mongodb
+
+RedHat:
   use_repo: True
   mongodb_package: mongodb-org
-  mongos_package: mongodb-org-mongos
+
+  mongodb_user: mongod
+  mongodb_group: mongod
+  mongod: mongod
+  conf_path: /etc/mongod.conf
+
+  mongod_settings:
+    systemLog:
+      destination: file
+      logAppend: true
+      path: /var/log/mongodb/mongod.log
+    storage:
+      dbPath: /var/lib/mongo
+      journal:
+        enabled: true
+    processManagement:
+      fork: true                                # fork and run in background
+      pidFilePath: /var/run/mongodb/mongod.pid  # location of pidfile
+    net:
+      port: 27017
+      bindIp: 127.0.0.1  # Listen to local interface only

--- a/mongodb/osmap.yaml
+++ b/mongodb/osmap.yaml
@@ -4,6 +4,7 @@ Debian:
   # Install MongoDB 2.4 from Debian repo
   use_repo: False
   mongodb_package: mongodb
+  repo_component: main
 
 RedHat:
   use_repo: True

--- a/mongodb/tools.sls
+++ b/mongodb/tools.sls
@@ -1,4 +1,4 @@
-{% from "mongodb/map.jinja" import mdb with context %}
+{%- from "mongodb/map.jinja" import mdb with context -%}
 
 python_pip:
   pkg.installed:

--- a/pillar.example
+++ b/pillar.example
@@ -1,51 +1,58 @@
+## For versions of Mongo that use the YAML format for configuration, use the
+## following. All entries in mongod_settings are written to the config file
+## verbatim. The storage:dbPath and systemLog:path entries are required in
+## this usage and take precedence over db_path at the top level (see references
+## in mongodb/init.sls).
 mongodb:
   use_repo: True
   version: 3.2
   repo_component: multiverse
   mongodb_package: mongodb-org
-  replica_set:
-    name: squiggles
-  config_svr: False
-  shard_svr: False
-  storage_engine: wiredTiger
-  db_path: /mongodb/data
+  mongodb_user: mongodb
+  mongodb_group: mongodb
+  mongod: mongod
+  conf_path: /etc/mongod.conf
   log_path: /mongodb/log
-  log_append: True
-  conf_path: /etc/mongodb.conf
-  rest: True
-  set_parameter:
-    textSearchEnabled: 'true'
-  settings:
-    bind_ip: 127.0.0.1
-    port: 27017
+  db_path: /mongodb/data
+  mongod_settings:
+    systemLog:
+      destination: file
+      logAppend: true
+      path: /var/log/mongodb/mongod.log
+    storage:
+      dbPath: /var/lib/mongodb
+      journal:
+        enabled: true
+    net:
+      port: 27017
+      bindIp: 0.0.0.0
+    setParameter:
+      textSearchEnabled: true
 
-## For versions of Mongo that use the YAML format for configuration, use the 
-## following. All entries in mongod_settings are written to the config file 
-## verbatim. The storage:dbPath and systemLog:path entries are required in
-## this usage and take precedence over db_path at the top level (see references
-## in mongodb/init.sls).
+## Use this for MongoDB 2.4
 # mongodb:
-#   conf_path: /etc/mongod.conf
-#   mongod: mongod
-#   version: 3.2
-#   mongod_settings:
-#     setParameter:
-#       textSearchEnabled: true
-#     net:
-#       port: 27017
-#       bindIp: 0.0.0.0
-#     storage:
-#       dbPath: /var/lib/mongodb
-#       journal:
-#         enabled: true
-#     systemLog:
-#       destination: file
-#       logAppend: true
-#       path: /var/log/mongodb/mongod.log
+#   use_repo: False
+#   mongodb_package: mongodb
+#   conf_path: /etc/mongodb.conf
+#   db_path: /mongodb/data
+#   log_path: /mongodb/log
+#   settings:
+#     log_append: True
+#     bind_ip: 0.0.0.0
+#     port: 27017
+#     journal: True
+#     configsvr: False
+#     shardsvr: True
+#     replSet: squiggles
+#     rest: False
+#     set_parameter:
+#       textSearchEnabled: 'true'
 
+## MongoDB query router configuration
 mongos:
   use_repo: True
   mongos_package: mongodb-org-mongos
+  log_path: /mongodb/log
   log_file: /mongodb/log/mongos.log
   settings:
     config_svrs: "cfg1.local:27019,cfg2.local:27019,cfg3.local:27019"

--- a/pillar.example
+++ b/pillar.example
@@ -6,7 +6,7 @@
 mongodb:
   use_repo: True
   version: 3.2
-  repo_component: multiverse
+  repo_component: multiverse    # this is for Ubuntu, use 'main' for Debian
   mongodb_package: mongodb-org
   mongodb_user: mongodb
   mongodb_group: mongodb


### PR DESCRIPTION
Hi.

This PR makes a lot of changes to fix the out-of-the-box installation and running latest stable MongoDB 3.X packages from official repo. Additionally, CentOS/RHEL systems are supported now.
Default configuration options, users and paths are mostly equal to the items provided by mongodb.org distribution. The formula was tested on all systems declared to be supported.

Thanks.