### PR TITLE
RedHat OS family: enable gpgcheck for MongoDB.org repo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ file). See `MongoDB reference manual`_ for additional information.
 ``mongodb.tools``
 -----------------
 
-Install additional tools and python libraries.
+Install additional tools and Python libraries.
 
 Operating systems support
 =========================


### PR DESCRIPTION
Security and integrity enhancement. Verify mongodb rpm packages with GPG PKI. 