### PR TITLE
Make mongos user and group configurable

### DIFF
--- a/mongodb/defaults.yaml
+++ b/mongodb/defaults.yaml
@@ -32,6 +32,9 @@ mongos:
   log_path: /var/log/mongos
   log_file: /var/log/mongos/mongos.log
   conf_path: /etc/mongos.conf
+  mongos_user: mongodb
+  mongos_user_home: /var/log/mongos
+  mongos_group: mongodb
   mongos: mongos
 
   settings:

--- a/mongodb/mongos.sls
+++ b/mongodb/mongos.sls
@@ -14,12 +14,19 @@ mongos_package:
   pkg.installed:
     - name: {{ ms.mongos_package }}
 
-mongodb_user:
+mongos_user:
   user.present:
-    - name: mongodb
+    - name: {{ ms.mongos_user }}
     - gid_from_name: True
-    - home: {{ ms.log_path }}
+    - home: {{ ms.mongos_user_home }}
     - shell: /bin/sh
+    - system: True
+    - require:
+      - group: mongos_group
+
+mongos_group:
+  group.present:
+    - name: {{ ms.mongos_group }}
     - system: True
 
 mongos_log_path:
@@ -29,8 +36,8 @@ mongos_log_path:
 {%- else %}
     - name: {{ ms.log_path }}
 {%- endif %}
-    - user: mongodb
-    - group: mongodb
+    - user: {{ ms.mongos_user }}
+    - group: {{ ms.mongos_group }}
     - mode: 755
     - makedirs: True
 


### PR DESCRIPTION
They certainly should be configurable.
There is also a one little feature: I suppose home directory for mongos user should not be hardcoded to ``log_path``, so I made it configurable while.
Backwards compatibilty was maintained.