### PR TITLE
Make mongos.conf.jinja understand yaml as well as mongodb.conf.jinja

### DIFF
--- a/mongodb/files/mongos.conf.jinja
+++ b/mongodb/files/mongos.conf.jinja
@@ -1,4 +1,14 @@
 {% from "mongodb/map.jinja" import ms with context -%}
+
+{%- if 'mongos_settings' in ms -%}
+
+# This file is managed by Salt!
+
+{{ ms.mongos_settings | yaml(false) }}
+
+{%- else -%}
+
 port={{ ms.settings.port }}
 logpath={{ ms.log_file }}
 configdb={{ ms.settings.config_svrs }}
+{%- endif %}

--- a/mongodb/mongos.sls
+++ b/mongodb/mongos.sls
@@ -24,7 +24,11 @@ mongodb_user:
 
 mongos_log_path:
   file.directory:
+{%- if 'mongos_settings' in ms %}
+    - name: {{ salt['file.dirname'](ms.mongos_settings.systemLog.path) }}
+{%- else %}
     - name: {{ ms.log_path }}
+{%- endif %}
     - user: mongodb
     - group: mongodb
     - mode: 755


### PR DESCRIPTION
Just as with mongodb.conf.jinja mongos.conf should be able to generate yaml-style configuration