### PR TITLE
Make keyid configurable for repositories

### DIFF
--- a/mongodb/defaults.yaml
+++ b/mongodb/defaults.yaml
@@ -4,6 +4,7 @@ mongodb:
   version: stable
 
   mongodb_package: mongodb
+  keyid: EA312927
   pip: python-pip
 
   # MongoDB 2.4 configuration

--- a/mongodb/init.sls
+++ b/mongodb/init.sls
@@ -15,7 +15,7 @@ mongodb_repo:
     - humanname: MongoDB.org Repository
     - name: deb http://repo.mongodb.org/apt/{{ os }} {{ code }}/mongodb-org/{{ mdb.version }} {{ mdb.repo_component }}
     - file: /etc/apt/sources.list.d/mongodb-org.list
-    - keyid: EA312927
+    - keyid: {{ mdb.keyid }}
     - keyserver: keyserver.ubuntu.com
 
   {%- elif grains['os_family'] == 'RedHat' %}

--- a/pillar.example
+++ b/pillar.example
@@ -48,6 +48,11 @@ mongodb:
 #     set_parameter:
 #       textSearchEnabled: 'true'
 
+## Use this for MongoDB 3.0 on Ubuntu
+# mongodb:
+#   version: 3.0
+#   keyid: 7F0CEB10 
+
 ## MongoDB query router configuration
 mongos:
   use_repo: True


### PR DESCRIPTION
The public key for the v3.0 repository is different to v3.2
See:
https://docs.mongodb.com/v3.0/tutorial/install-mongodb-on-ubuntu/#import-the-public-key-used-by-the-package-management-system