### PR TITLE
Restore SELinux security context to DB dir

### DIFF
--- a/mongodb/init.sls
+++ b/mongodb/init.sls
@@ -80,6 +80,15 @@ mongodb_db_path:
       - user
       - group
 
+{% if salt['grains.get']('selinux:enabled') == True %}
+mongodb_db_path_restorecon:
+  selinux.fcontext_policy_applied:
+    - name: {{ mdb.mongod_settings.storage.dbPath }}
+    - recursive: True
+    - require:
+      - file: {{ mdb.mongod_settings.storage.dbPath }}
+{% endif %}
+
 mongodb_config:
   file.managed:
     - name: {{ mdb.conf_path }}

--- a/mongodb/init.sls
+++ b/mongodb/init.sls
@@ -80,13 +80,15 @@ mongodb_db_path:
       - user
       - group
 
-{% if salt['grains.get']('selinux:enabled') == True %}
+{% if salt['grains.get']('selinux:enabled') %}
+
 mongodb_db_path_restorecon:
   selinux.fcontext_policy_applied:
     - name: {{ mdb.mongod_settings.storage.dbPath }}
     - recursive: True
     - require:
-      - file: {{ mdb.mongod_settings.storage.dbPath }}
+      - file: mongodb_db_path
+
 {% endif %}
 
 mongodb_config:


### PR DESCRIPTION
If SELinux is enabled and the DB directory is created under /var/lib (the default location), the DB directory may be created with security context "var_lib_t". Unless security context is restored to "mongod_var_lib_t" mongod will fail to start.