### PR TITLE
Change logic to repo install

### DIFF
--- a/mongodb/oscodemap.yaml
+++ b/mongodb/oscodemap.yaml
@@ -20,6 +20,7 @@
       file: /etc/apt/sources.list.d/mongodb-org-RELEASE.list
       keyid: 9DA31620334BD75D9DCB49F368818C72E52529D4
       keyserver: hkp://keyserver.ubuntu.com:80
+      from_repo_value: '{{ codename }}'
 
     {%- else %}
 
@@ -27,7 +28,8 @@
       name: mongodb-org-RELEASE
       humanname: MongoDB RELEASE Repository
       gpgkey: 'https://www.mongodb.org/static/pgp/server-RELEASE.asc'
-
+      from_repo_value: {{ mongodb.server.repo.name|replace('RELEASE', mongodb.server.version) or None }}
+      
     {%- endif %}
 {% endmacro %}
 

--- a/mongodb/server/packages.sls
+++ b/mongodb/server/packages.sls
@@ -34,6 +34,6 @@ mongodb server package installed:
     - refresh: True
     - name: {{ mongodb.server.package }}
         {%- if mongodb.server.use_repo %}
-    - fromrepo: {{ mongodb.server.repo.name|replace('RELEASE', mongodb.server.version) or None }}
+    - fromrepo: {{ mongodb.server.repo.from_repo_value }}
         {%- endif %}
 


### PR DESCRIPTION
apt based systems need the codename of the distro in the "fromrepo" param when installing the package

tested on Debian 9 and Ubuntu 18.04

Proposed solution to #61 