### PR TITLE
fix(jinja): fix 'mongodb' not found jinja error

### DIFF
--- a/mongodb/oscodemap.yaml
+++ b/mongodb/oscodemap.yaml
@@ -28,7 +28,7 @@
       name: mongodb-org-RELEASE
       humanname: MongoDB RELEASE Repository
       gpgkey: 'https://www.mongodb.org/static/pgp/server-RELEASE.asc'
-      from_repo_value: {{ mongodb.server.repo.name|replace('RELEASE', mongodb.server.version) or None }}
+      from_repo_value: ''
       
     {%- endif %}
 {% endmacro %}

--- a/mongodb/osfamilymap.yaml
+++ b/mongodb/osfamilymap.yaml
@@ -2,6 +2,10 @@
 # -*- coding: utf-8 -*-
 # vim: ft=yaml
 
+Arch:
+  server:
+    use_repo: false
+
 Debian:
   server:
     #deb unofficial packages conflict with MongoDB offical supported packages

--- a/mongodb/server/packages.sls
+++ b/mongodb/server/packages.sls
@@ -35,6 +35,5 @@ mongodb server package installed:
     - name: {{ mongodb.server.package }}
         {%- if mongodb.server.use_repo %}
     - fromrepo: {{ mongodb.server.repo.from_repo_value or mongodb.server.repo.name|replace('RELEASE', mongodb.server.version) or None }}
- }}
         {%- endif %}
 

--- a/mongodb/server/packages.sls
+++ b/mongodb/server/packages.sls
@@ -34,6 +34,7 @@ mongodb server package installed:
     - refresh: True
     - name: {{ mongodb.server.package }}
         {%- if mongodb.server.use_repo %}
-    - fromrepo: {{ mongodb.server.repo.from_repo_value }}
+    - fromrepo: {{ mongodb.server.repo.from_repo_value or mongodb.server.repo.name|replace('RELEASE', mongodb.server.version) or None }}
+ }}
         {%- endif %}
 


### PR DESCRIPTION
This PR fixes jinja rendering error.

```
    Rendering SLS 'base:mongodb.compass' failed: Jinja variable 'mongodb' is undefined
/var/cache/salt/minion/files/base/mongodb/oscodemap.yaml(31):
---
[...]

      baseurl: 'https://repo.mongodb.org/yum/redhat/$releasever/mongodb-org/RELEASE/$basearch/'
      name: mongodb-org-RELEASE
      humanname: MongoDB RELEASE Repository
      gpgkey: 'https://www.mongodb.org/static/pgp/server-RELEASE.asc'
      from_repo_value: {{ mongodb.server.repo.name|replace('RELEASE', mongodb.server.version) or None }}    <======================
```