### PR TITLE
[fix] debian: remove firewalld from dependencies

### DIFF
--- a/mongodb/osfamilymap.yaml
+++ b/mongodb/osfamilymap.yaml
@@ -23,7 +23,6 @@ Arch:
       - tar
       - curl
       - openssl
-      - firewalld
 
 Alpine: {}
 
@@ -36,7 +35,6 @@ Debian:
       - openssl
       - tar
       - unzip
-      - firewalld
     repo:
       file: /etc/apt/sources.list.d/mongodb-org-REL.list
       from_repo_value: {{ '' if 'oscodename' not in grains else grains.oscodename }}
@@ -73,7 +71,6 @@ RedHat:
       - openssl
       - tar
       - unzip
-      - firewalld
       - {{ 'policycoreutils' if grains.osrelease|int >= 8 else 'policycoreutils-python' }}
       - selinux-policy-targeted
     repo:


### PR DESCRIPTION
Sorry, but not everyone uses firewalld, installing it if firewall is handled
any other way is a security risk.

It would still be explicitly installed and configured if firewall pillar are
configured.

### What type of PR is this?

Remote firewalld from prereq on Debian

### Does this PR introduce a `BREAKING CHANGE`?

Might break deployment that rely on the formula to install firewalld. Would not break any running host.

Can configuring it explicitly in pillars still allow to install it.

### Related issues and/or pull requests

Fixes https://github.com/saltstack-formulas/mongodb-formula/issues/91 

Tested on Debian only.