### PR TITLE
feat(repository): only take keys with values

### DIFF
--- a/mongodb/install.sls
+++ b/mongodb/install.sls
@@ -78,7 +78,11 @@ include:
                         {%- if package in ('native', 'repo') %}
                             {%- if package == 'repo' and 'repo' in d.pkg and d.pkg.repo %}
   pkgrepo.managed:
-    {{- format_kwargs(d.pkg['repo']) }}
+    {%- for k, v in d.pkg.repo|dictsort %}
+    {%-   if v %}
+    - {{ k }}: {{ v|json }}
+    {%-   endif %}
+    {%- endfor %}
                             {%- endif %}
   pkg.installed:
                             {%- if package in software and software[package] is mapping %}


### PR DESCRIPTION
Allows to remove keys from default by overriding them with empty values.
Required to remove keyid/keyserver and use key_url

Exemple:
```
mongodb:
  wanted:
    database:
    - mongod
    - dbtools
    - shell
  pkg:
    repo:
      file: /etc/apt/sources.list.d/mongodb-org-REL.list
      from_repo_value: {{ __grains__.oscodename }}
      # key from https://www.mongodb.org/static/pgp/server-4.4.asc
      # deb http://repo.mongodb.org/apt/debian buster/mongodb-org/4.4 main
      key_url: salt://repositories/keys/mongodb-4.4.key
      keyid: ""
      keyserver: ""
      # keyid: 9DA31620334BD75D9DCB49F368818C72E52529D4
      # keyserver: hkp://keyserver.ubuntu.com:80
      name: deb [arch=amd64] http://repo.mongodb.org/apt/debian/ {{ __grains__.oscodename }}/mongodb-org/REL main
      # yamllint enable-line rule:line-length

    database:
      dbtools:
        use_upstream: 'repo'
      shell:
        use_upstream: 'repo'
      mongod:
        version: "4.4"
        use_upstream: 'repo'
```

(partial config I use, with repo URL changed, as we use a mirror, and not always have open access to internet)
